### PR TITLE
当景点新加不添加酒店时报错

### DIFF
--- a/thinkphp/application/index/service/Articleservice.php
+++ b/thinkphp/application/index/service/Articleservice.php
@@ -143,11 +143,12 @@ class Articleservice
             $hotelId = $value->hotel_id;
             if(!is_null($hotelId)) {
                 $tempHotel = Hotel::where('id', $hotelId)->find();
+                if (!is_null($tempHotel)) {
+                    //如果酒店不为空
+                    array_push($Hotels, $tempHotel);
+                }
             }
-            if (!is_null($tempHotel)) {
-                //如果酒店不为空
-                array_push($Hotels, $tempHotel);
-            }
+
             $tempHotel = null;
         }
         // 将段落按在景点的上下顺序分成两个类，并根据权重排序


### PR DESCRIPTION
bug修复
原因：$tempHotel = new Hotel();这个对象不为空，原来代码使用is_null判断这个是否存进数组的，所以会传一个没有数据表信息的非空对象过去。