### PR TITLE
删除文章时，unlink(upload/): Permission denied错误

### DIFF
--- a/thinkphp/application/index/service/Articleservice.php
+++ b/thinkphp/application/index/service/Articleservice.php
@@ -61,6 +61,8 @@ class Articleservice
                 $message['status'] = 'error';
                 $message['message'] = '请上传图片';
                 $message['route'] = 'firstadd';
+
+                return $message;
             }
         }
         


### PR DESCRIPTION
resolve #166 
该问题是由于数据库中对应的cover一栏信息为空所致，由于未上传图片时会保存一条cover为空的数据才造成的bug