### PR TITLE
当素材库为空时，添加景点后跳转界面secondadd会报错

### DIFF
--- a/thinkphp/application/index/model/Attraction.php
+++ b/thinkphp/application/index/model/Attraction.php
@@ -64,6 +64,13 @@ class Attraction extends Model {
 
     public function getMaterial($id) {
         //返回关联的素材
-        return Material::get($id);
+        if(!is_null($id)) {
+            return Material::get($id);
+        } else {
+            $Material = new Material();
+            $Material->image = '';
+            $Material->designation = '未选择素材';
+            return $Material;
+        }
     }
 }


### PR DESCRIPTION
resolve #204 