### PR TITLE
素材管理首页slider显示有问题(点击第二个的素材滑动第一个却动了)

### DIFF
--- a/thinkphp/application/index/view/material/index.html
+++ b/thinkphp/application/index/view/material/index.html
@@ -24,17 +24,17 @@
         </div>
 
         <ul class="container list-unstyled" style="min-height: 570px;">
-            {volist name="materials" id="material"}
+            {volist name="materials" id="material" key="i"}
             <li style="list-style-type: none;">
                 <div class="panel panel-default">
                     <div class="panel-body">
                         <h4>{$material->designation}</h4>
                         <div class="row">
                             <!--轮播图-->
-                            <div id="carousel-example-generic" class="col-md-3 carousel slide" data-ride="carousel" style="height:150px;width:300px;">
+                            <div id="carousel-example-generic-{$i}" class="col-md-3 carousel slide" data-ride="carousel" style="height:150px;width:300px;">
                                 <ol class="carousel-indicators">
                                     {volist name="$material->getMaterialImages()" id="image" key="key"}
-                                    <li data-target="#carousel-example-generic" data-slide-to="{$key}"></li>
+                                    <li data-target="#carousel-example-generic-{$i}" data-slide-to="{$key}"></li>
                                     {/volist}
                                 </ol>
 
@@ -48,11 +48,11 @@
                                     {/volist}
                                 </div>
 
-                                <a class="left carousel-control" href="#carousel-example-generic" role="button" data-slide="prev">
+                                <a class="left carousel-control" href="#carousel-example-generic-{$i}" role="button" data-slide="prev">
                                     <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
                                     <span class="sr-only">Previous</span>
                                 </a>
-                                <a class="right carousel-control" href="#carousel-example-generic" role="button" data-slide="next">
+                                <a class="right carousel-control" href="#carousel-example-generic-{$i}" role="button" data-slide="next">
                                     <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
                                     <span class="sr-only">Next</span>
                                 </a>


### PR DESCRIPTION
resolve #439 
轮播图bug修复