### PR TITLE
将编辑firstadd界面时编辑路线图设置为不显示

### DIFF
--- a/thinkphp/application/index/view/article/firstadd.html
+++ b/thinkphp/application/index/view/article/firstadd.html
@@ -35,19 +35,7 @@
                 {eq name="$cover" value=""} {else /}
                 <img src="{:__ROOT__}/upload/{$cover}" style="height: 100px; width: 180px; " alt=""> {/eq}
             </div>
-            <div class="form-group">
-                <label for="torvelRoutes">路线图</label>
-                <input type="file" id="torvelRoutes" name="routes" class="image-file">
-
-                {eq name="$route" value="1"}{else /} 
-                <img src="{:__ROOT__}/upload/{$route}" style="height: 100px; width: 180px; " alt="">
-                {/eq}
-            </div>
-            <div class="form-group">
-                <label for="judgeRoute">是否添加路线图</label>
-                <input type="radio" name="optionsRadios" id="optionsRadios1" value="1" checked>是
-                <input type="radio" name="optionsRadios" id="optionsRadios1" value="0">否
-            </div>
+           
             
             <br>
             <div class="form-group">
@@ -63,6 +51,19 @@
                 </span>
             </div>
             {eq name="$articleId" value=""}
+             <div class="form-group">
+                <label for="torvelRoutes">路线图</label>
+                <input type="file" id="torvelRoutes" name="routes" class="image-file">
+
+                {eq name="$route" value="1"}{else /} 
+                <img src="{:__ROOT__}/upload/{$route}" style="height: 100px; width: 180px; " alt="">
+                {/eq}
+            </div>
+            <div class="form-group">
+                <label for="judgeRoute">是否添加路线图</label>
+                <input type="radio" name="optionsRadios" id="optionsRadios1" value="1" checked>是
+                <input type="radio" name="optionsRadios" id="optionsRadios1" value="0">否
+            </div>
             <div class="form-group">
                 <label>是否添加九大服务</label>
                 <input type="radio" name="especialMassageService"  value="九大服务" checked>是


### PR DESCRIPTION
以前在secondadd界面删除路线图后，在firstadd界面无法重新添加